### PR TITLE
If not running in main thread, create & set a new event loop.

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,24 +48,33 @@ Import
 ```
 from TikTokAPI import TikTokAPI
 ```
+Get your keys from Cookie. You can get them from the Applications tab in Chrome developer console.  
+By default it used hardcoded values which may not work after some time.  
+The keys to extract are `s_v_web_id` and `tt_webid`
+```
+cookie = {
+  "s_v_web_id": "<your_key>",
+  "tt_webid": "<your_key>"
+}
+```
 Get the most trending Videos on TikTok
 ```
-api = TikTokAPI()
+api = TikTokAPI(cookie=cookie)
 retval = api.getTrending(count=5)
 ```
 Get a user by name
 ```
-api = TikTokAPI()
+api = TikTokAPI(cookie=cookie)
 user_obj = api.getUserByName("fcbarcelona")
 ```
 Get videos of a user
 ```
-api = TikTokAPI()
+api = TikTokAPI(cookie=cookie)
 user_videos = api.getVideosByUserName("fcbarcelona")
 ```
 Get likes of a user
 ```
-api = TikTokAPI()
+api = TikTokAPI(cookie=cookie)
 user_videos = api.getLikesByUserName("fcbarcelona")
 ```
 

--- a/TikTokAPI/tiktok_browser.py
+++ b/TikTokAPI/tiktok_browser.py
@@ -1,6 +1,6 @@
 import os
 import asyncio
-from pyppeteer import launch
+from pyppeteer import launcher
 from .utils import python_list2_web_list
 
 
@@ -62,7 +62,8 @@ class TikTokBrowser:
         return asyncio.get_event_loop().run_until_complete(self.async_fetch_auth_params(url, language))
 
     async def async_fetch_auth_params(self, url, language):
-        browser = await launch(self.options)
+        pplauncher = launcher.Launcher(self.options)
+        browser = await pplauncher.launch()
         page = await browser.newPage()
 
         await page.evaluateOnNewDocument("""() => {
@@ -88,5 +89,7 @@ class TikTokBrowser:
                 return token;
             }''')
 
+        await page.close()
         await browser.close()
+        await pplauncher.killChrome()
         return signature

--- a/TikTokAPI/tiktok_browser.py
+++ b/TikTokAPI/tiktok_browser.py
@@ -57,10 +57,8 @@ class TikTokBrowser:
         # new event loop.
         try:
             asyncio.get_event_loop()
-            print('get_event_loop')
         except RuntimeError:
             asyncio.set_event_loop(asyncio.new_event_loop())
-            print('new_event_loop')
 
         return asyncio.get_event_loop().run_until_complete(self.async_fetch_auth_params(url, language))
 

--- a/TikTokAPI/tiktok_browser.py
+++ b/TikTokAPI/tiktok_browser.py
@@ -7,6 +7,14 @@ from .utils import python_list2_web_list
 class TikTokBrowser:
 
     def __init__(self, user_agent):
+
+        # If not running in the main thread, it's necessary to create & set a
+        # new event loop.
+        try:
+            asyncio.get_event_loop()
+        except RuntimeError:
+            asyncio.set_event_loop(asyncio.new_event_loop())
+
         self.userAgent = user_agent
         self.args = [
             "--no-sandbox",

--- a/TikTokAPI/tiktok_browser.py
+++ b/TikTokAPI/tiktok_browser.py
@@ -8,13 +8,6 @@ class TikTokBrowser:
 
     def __init__(self, user_agent):
 
-        # If not running in the main thread, it's necessary to create & set a
-        # new event loop.
-        try:
-            asyncio.get_event_loop()
-        except RuntimeError:
-            asyncio.set_event_loop(asyncio.new_event_loop())
-
         self.userAgent = user_agent
         self.args = [
             "--no-sandbox",
@@ -59,6 +52,16 @@ class TikTokBrowser:
         self.tiktok_dummy_page = "file://" + os.path.join(parent_folder, "website", "tiktok.html")
 
     def fetch_auth_params(self, url, language='en'):
+
+        # If not running in the main thread, it's necessary to create & set a
+        # new event loop.
+        try:
+            asyncio.get_event_loop()
+            print('get_event_loop')
+        except RuntimeError:
+            asyncio.set_event_loop(asyncio.new_event_loop())
+            print('new_event_loop')
+
         return asyncio.get_event_loop().run_until_complete(self.async_fetch_auth_params(url, language))
 
     async def async_fetch_auth_params(self, url, language):

--- a/TikTokAPI/tiktokapi.py
+++ b/TikTokAPI/tiktokapi.py
@@ -9,15 +9,17 @@ from .tiktok_browser import TikTokBrowser
 class VideoException(Exception):
     pass
 
+
 class TikTokAPI(object):
 
-    def __init__(self, cookie={}, language='en', browser_lang="en-US", timezone="Asia/Kolkata", region='IN'):
+    def __init__(self, cookie=None, language='en', browser_lang="en-US", timezone="Asia/Kolkata", region='IN'):
         self.base_url = "https://t.tiktok.com/api"
         self.user_agent = "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:79.0) Gecko/20100101 Firefox/79.0"
 
+        if cookie is None:
+            cookie = {}
         self.verifyFp = cookie.get("s_v_web_id", "verify_kjf974fd_y7bupmR0_3uRm_43kF_Awde_8K95qt0GcpBk")
         self.tt_webid = cookie.get("tt_webid", "6913027209393473025")
-
 
         self.headers = {
             'Host': 't.tiktok.com',
@@ -134,7 +136,7 @@ class TikTokAPI(object):
         for key, val in self.default_params.items():
             params[key] = val
         return self.send_get_request(url, params)
-    
+
     def getLikesByUserName(self, user_name, count=30):
         user_data = self.getUserByName(user_name)
         user_obj = user_data["userInfo"]["user"]
@@ -249,7 +251,7 @@ class TikTokAPI(object):
             raise VideoException("Video without watermark not available in new videos")
         video_url_no_wm = "https://api2-16-h2.musical.ly/aweme/v1/play/?video_id={" \
                           "}&vr_type=0&is_play_url=1&source=PackSourceEnum_PUBLISH&media_type=4" \
-            .format(video_data[pos+4:pos+36])
+            .format(video_data[pos + 4:pos + 36])
 
         video_data_no_wm = get_req_content(video_url_no_wm, params=None, headers=self.headers)
         with open(save_path, 'wb') as f:

--- a/TikTokAPI/tiktokapi.py
+++ b/TikTokAPI/tiktokapi.py
@@ -1,4 +1,5 @@
 import os
+import string
 import random
 import urllib.parse
 from .utils import random_key, build_get_url, get_req_json, get_req_content, get_req_text
@@ -12,7 +13,9 @@ class TikTokAPI(object):
         self.user_agent = "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:79.0) Gecko/20100101 Firefox/79.0"
 
         self.headers = {
-            "User-Agent": self.user_agent,
+            'Host': 't.tiktok.com',
+            'User-Agent': 'Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:79.0) Gecko/20100101 Firefox/79.0',
+            # 'Cookie': 'tt_webid_v2=6913043173028431361; tt_webid=6913043173028431361; tt_csrf_token=taRJpJNwpA9NmrpdiwSwaysu'
         }
         self.language = language
         self.browser_lang = browser_lang
@@ -20,7 +23,7 @@ class TikTokAPI(object):
         self.region = region
 
         if cookie is None:
-            self.verifyFp = random_key(16)
+            self.verifyFp = "verify_kjfaff24_sOZVAInw_G0Sm_4BtI_BStb_SB6moxzLxFrr"
         else:
             self.verifyFp = cookie
         self.default_params = {
@@ -60,7 +63,7 @@ class TikTokAPI(object):
 
     def send_get_request(self, url, params, extra_headers=None):
         url = build_get_url(url, params)
-        did = str(random.randint(10000, 999999999))
+        did = ''.join(random.choice(string.digits) for num in range(19))
         url = build_get_url(url, {self.did_key: did}, append=True)
         signature = self.tiktok_browser.fetch_auth_params(url, language=self.language)
         url = build_get_url(url, {self.signature_key: signature}, append=True)
@@ -95,9 +98,10 @@ class TikTokAPI(object):
         return self.send_get_request(url, params)
 
     def getUserByName(self, user_name):
-        url = self.base_url + "/user/detail/"
+        url = "https://t.tiktok.com/node/share/user/@" + user_name
         params = {
-            "uniqueId": user_name
+            "uniqueId": user_name,
+            "validUniqueId": user_name,
         }
         for key, val in self.default_params.items():
             params[key] = val
@@ -164,7 +168,7 @@ class TikTokAPI(object):
         hashTag = hashTag.replace("#", "")
         hashTag_obj = self.getHashTag(hashTag)
         hashTag_id = hashTag_obj["challengeInfo"]["challenge"]["id"]
-        url = "https://m.tiktok.com/share/item/list"
+        url = self.base_url + "/challenge/item_list/"
         req_default_params = {
             "secUid": "",
             "type": "3",
@@ -174,8 +178,9 @@ class TikTokAPI(object):
             "recType": ""
         }
         params = {
-            "id": str(hashTag_id),
+            "challengeID": str(hashTag_id),
             "count": str(count),
+            "cursor": "0",
         }
         for key, val in req_default_params.items():
             params[key] = val
@@ -194,7 +199,7 @@ class TikTokAPI(object):
         return self.send_get_request(url, params)
 
     def getVideosByMusic(self, music_id, count=30):
-        url = "https://m.tiktok.com/share/item/list"
+        url = self.base_url + "/music/item_list/"
         req_default_params = {
             "secUid": "",
             "type": "4",
@@ -204,8 +209,9 @@ class TikTokAPI(object):
             "recType": ""
         }
         params = {
-            "id": str(music_id),
+            "musicID": str(music_id),
             "count": str(count),
+            "cursor": "0",
         }
         for key, val in req_default_params.items():
             params[key] = val

--- a/TikTokAPI/utils.py
+++ b/TikTokAPI/utils.py
@@ -24,16 +24,19 @@ def build_get_url(base_url, params, append=False):
 
 
 def get_req_json(url, params=None, headers=None):
+    headers["Host"] = url.split("/")[2]
     r = requests.get(url, params=params, headers=headers)
     return json.loads(r.text)
 
 
 def get_req_content(url, params=None, headers=None):
+    headers["Host"] = url.split("/")[2]
     r = requests.get(url, params=params, headers=headers)
     return r.content
 
 
 def get_req_text(url, params=None, headers=None):
+    headers["Host"] = url.split("/")[2]
     r = requests.get(url, params=params, headers=headers)
     return r.text
 

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.md", "r") as fh:
 setuptools.setup(
     name="PyTikTokAPI",
     packages=setuptools.find_packages(),
-    version="0.0.4",
+    version="0.0.5",
     license='MIT',
     author="Avilash Kumar",
     author_email="avilashkumar4@gmail.com",

--- a/tests/cookie.json
+++ b/tests/cookie.json
@@ -1,0 +1,4 @@
+{
+  "s_v_web_id": "verify_kjf974fd_y7bupmR0_3uRm_43kF_Awde_8K95qt0GcpBk",
+  "tt_webid": "6913027209393473025"
+}

--- a/tests/test_hashtag.py
+++ b/tests/test_hashtag.py
@@ -1,14 +1,15 @@
 import argparse
 from TikTokAPI import TikTokAPI
+from utils import read_json_from_file
 
 
 def getHashTag(hashTag):
-    api = TikTokAPI()
+    api = TikTokAPI(read_json_from_file("cookie.json"))
     return api.getHashTag(hashTag)
 
 
 def getVideosByHashTag(hashTag):
-    api = TikTokAPI()
+    api = TikTokAPI(read_json_from_file("cookie.json"))
     return api.getVideosByHashTag(hashTag, count=10)
 
 

--- a/tests/test_music.py
+++ b/tests/test_music.py
@@ -1,14 +1,15 @@
 import argparse
 from TikTokAPI import TikTokAPI
+from utils import read_json_from_file
 
 
 def getMusic(music_id):
-    api = TikTokAPI()
+    api = TikTokAPI(read_json_from_file("cookie.json"))
     return api.getMusic(music_id)
 
 
 def getVideosByMusic(music_id):
-    api = TikTokAPI()
+    api = TikTokAPI(read_json_from_file("cookie.json"))
     return api.getVideosByMusic(music_id, count=10)
 
 

--- a/tests/test_trending.py
+++ b/tests/test_trending.py
@@ -1,6 +1,7 @@
 from TikTokAPI import TikTokAPI
+from utils import read_json_from_file
 
-api = TikTokAPI()
+api = TikTokAPI(read_json_from_file("cookie.json"))
 retval = api.getTrending(count=5)
 print("Trending Videos")
 print(retval)

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -1,19 +1,20 @@
 import argparse
 from TikTokAPI import TikTokAPI
+from utils import read_json_from_file
 
 
 def getUser(user_name):
-    api = TikTokAPI()
+    api = TikTokAPI(read_json_from_file("cookie.json"))
     return api.getUserByName(user_name)
 
 
 def getVideosByUserName(user_name):
-    api = TikTokAPI()
+    api = TikTokAPI(read_json_from_file("cookie.json"))
     return api.getVideosByUserName(user_name, count=1)
 
 
 def getLikesByUserName(user_name):
-    api = TikTokAPI()
+    api = TikTokAPI(read_json_from_file("cookie.json"))
     return api.getLikesByUserName(user_name, count=1)
 
 

--- a/tests/test_video.py
+++ b/tests/test_video.py
@@ -1,19 +1,20 @@
 import argparse
 from TikTokAPI import TikTokAPI
+from utils import read_json_from_file
 
 
 def getVideoById(video_id):
-    api = TikTokAPI()
+    api = TikTokAPI(read_json_from_file("cookie.json"))
     return api.getVideoById(video_id)
 
 
 def downloadVideoById(video_id):
-    api = TikTokAPI()
+    api = TikTokAPI(read_json_from_file("cookie.json"))
     api.downloadVideoById(video_id, video_id+".mp4")
 
 
 def downloadVideoByIdNoWatermark(video_id):
-    api = TikTokAPI()
+    api = TikTokAPI(read_json_from_file("cookie.json"))
     api.downloadVideoByIdNoWatermark(video_id, video_id+"_no_wm.mp4")
 
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,9 @@
+import json
+
+
+def read_json_from_file(filepath):
+    with open(filepath, 'r', encoding='utf-8') as json_file:
+        data = json.load(json_file)
+    if type(data) is str:
+        return json.loads(data)
+    return data


### PR DESCRIPTION
When running `TikTokAPI-Python` in a subthread, I encountered an error:
```bash
RuntimeError: There is no current event loop in thread 'ThreadPoolExecutor-0_0'.
```
This RuntimeError does **not** occur when I use `TikTokAPI-Python` directly in a script (i.e. in the main python thread), but it does occur when calling `TikTokAPI-Python` from another (multithreaded) application. As far as I can see, if not running in the main thread, it's necessary to create & set a new event loop.

My proposed solution should not alter anything if running in the main thread, but avoid trouble otherwise.