### PR TITLE
Added syntax highlighting for code segments

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,47 +33,47 @@ To get started using this API, follow the instructions below.
 
 ### Installing
 Pip
-```
+```shell
 pip install PyTikTokAPI
 ```
 
 Install from source
-```
+```shell
 git clone https://github.com/avilash/TikTokAPI-Python.git
 python setup.py install
 ```
 
 ## Quick Start Guide
 Import
-```
+```python
 from TikTokAPI import TikTokAPI
 ```
 Get your keys from Cookie. You can get them from the Applications tab in Chrome developer console.  
 By default it used hardcoded values which may not work after some time.  
 The keys to extract are `s_v_web_id` and `tt_webid`
-```
+```python
 cookie = {
   "s_v_web_id": "<your_key>",
   "tt_webid": "<your_key>"
 }
 ```
 Get the most trending Videos on TikTok
-```
+```python
 api = TikTokAPI(cookie=cookie)
 retval = api.getTrending(count=5)
 ```
 Get a user by name
-```
+```python
 api = TikTokAPI(cookie=cookie)
 user_obj = api.getUserByName("fcbarcelona")
 ```
 Get videos of a user
-```
+```python
 api = TikTokAPI(cookie=cookie)
 user_videos = api.getVideosByUserName("fcbarcelona")
 ```
 Get likes of a user
-```
+```python
 api = TikTokAPI(cookie=cookie)
 user_videos = api.getLikesByUserName("fcbarcelona")
 ```
@@ -89,7 +89,7 @@ Inputs
 * region - Self explanatory
 * cookie - The TikTok Cookie containing the parameter <em>s_v_web_id</em>. If not provided, the parameter will be generated.
 
-```buildoutcfg
+```python
 __init__(self, language='en', region='IN', cookie=None)
 ```
 
@@ -97,7 +97,7 @@ __init__(self, language='en', region='IN', cookie=None)
 Inputs
 * count - Number of videos to fetch  
 
-```buildoutcfg
+```python
 getTrending(self, count=30)
 ```
 
@@ -105,7 +105,7 @@ getTrending(self, count=30)
 Inputs
 * user_name - Username, eg - <em>fcbarcelona</em>
 
-```buildoutcfg
+```python
 getUserByName(self, user_name)
 ```
 
@@ -114,7 +114,7 @@ Inputs
 * user_name - Username, eg - <em>fcbarcelona</em>
 * count - Number of videos to fetch
 
-```buildoutcfg
+```python
 getVideosByUserName(self, user_name, count=30)
 ```
 
@@ -123,7 +123,7 @@ Inputs
 * user_name - Username, eg - <em>fcbarcelona</em>
 * count - Number of videos to fetch
 
-```buildoutcfg
+```python
 getLikesByUserName(self, user_name, count=30)
 ```
 
@@ -131,7 +131,7 @@ getLikesByUserName(self, user_name, count=30)
 Inputs
 * hashTag - HashTag, eg - <em>#fcbarcelona</em>
 
-```buildoutcfg
+```python
 getHashTag(self, hashTag)
 ```
 
@@ -140,7 +140,7 @@ Inputs
 * hashTag - HashTag, eg - <em>#fcbarcelona</em>
 * count - Number of videos to fetch
 
-```buildoutcfg
+```python
 getVideosByHashTag(self, hashTag, count=30)
 ```
 
@@ -148,7 +148,7 @@ getVideosByHashTag(self, hashTag, count=30)
 Inputs
 * music_id - Music Id, eg - <em>6704854531001289474</em>
 
-```buildoutcfg
+```python
 getMusic(self, music_id)
 ```
 
@@ -157,7 +157,7 @@ Inputs
 * music_id - Music Id, eg - <em>6704854531001289474</em>
 * count - Number of videos to fetch
 
-```buildoutcfg
+```python
 getVideosByMusic(self, music_id, count=30)
 ```
 
@@ -165,7 +165,7 @@ getVideosByMusic(self, music_id, count=30)
 Inputs
 * video_id - Video Id, eg - <em>6843481669886954757</em>
 
-```buildoutcfg
+```python
 getVideoById(self, video_id)
 ```
 
@@ -174,7 +174,7 @@ Inputs
 * video_id - Video Id, eg - <em>6843481669886954757</em>
 * save_path - Path where the downloaded video should be saved
 
-```buildoutcfg
+```python
 downloadVideoById(self, video_id, save_path)
 ```
 
@@ -183,7 +183,7 @@ Inputs
 * video_id - Video Id, eg - <em>6843481669886954757</em>
 * save_path - Path where the downloaded video should be saved
 
-```buildoutcfg
+```python
 downloadVideoByIdNoWatermark(self, video_id, save_path)
 ```
 


### PR DESCRIPTION
Made updates to the \`\`\` code blocks to define the correct language for each code block. 

The main changes were identifying:
- Shell Code
- Python Code
- Removing `buildoutcfg` which is not a recognized code type on GitHub

Made changes from:

[GitHub syntax highlighting guide](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks)